### PR TITLE
Add cross-platform build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,26 @@
+---
+name: Build
+
+'on':
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.11
+      - run: python -m pip install --upgrade pip build
+      - run: python -m build .
+      - uses: actions/upload-artifact@v4
+        with:
+          name: open-webui-${{ matrix.os }}
+          path: dist/*


### PR DESCRIPTION
## Summary
- add manual build workflow compiling artifacts for Ubuntu, Windows, and macOS

## Testing
- `yamllint .github/workflows/build.yml`


------
https://chatgpt.com/codex/tasks/task_e_68a9355a5ab8832dba6875277ebec9c2