### PR TITLE
Fix PyInstaller invocation in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,12 +33,13 @@ jobs:
       - run: |
           python - <<'PY'
           import pathlib, open_webui, subprocess, os
-          base = pathlib.Path(open_webui.__file__).resolve().parent
+          script_path = pathlib.Path(open_webui.__file__).resolve()
+          base = script_path.parent
           data_path = base/'frontend'
           sep = os.environ['PATHSEP']
           subprocess.run([
               'pyinstaller',
-              '-m', 'open_webui',
+              str(script_path),
               '--name', 'open-webui',
               '--onefile',
               '--distpath', 'dist-bin',


### PR DESCRIPTION
## Summary
- fix PyInstaller call by using the installed `open_webui` script path instead of `-m`

## Testing
- `npx prettier .github/workflows/build.yml --check` *(fails: Cannot find package 'prettier-plugin-svelte')*

------
https://chatgpt.com/codex/tasks/task_e_68a97fc26d5c832da0f85fbc02d3547c