### PR TITLE
Fix Windows PyInstaller entry script detection

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,7 +114,7 @@ jobs:
           if not path:
               raise SystemExit('entry script not found')
           p = pathlib.Path(path)
-          if p.suffix == '.exe':
+          if p.suffix.lower() == '.exe':
               p = p.with_name(p.stem + '-script.py')
           if not p.exists():
               raise SystemExit(f'{p} not found')


### PR DESCRIPTION
## Summary
- handle uppercase entry point extension when locating Windows open-webui script

## Testing
- `npm test` *(fails: Missing script "test")*
- `python -m pytest` *(errors: ModuleNotFoundError: test.util, boto3, docker, redis)*

------
https://chatgpt.com/codex/tasks/task_e_68aa264273c0832d96c8b3ed28b40dd5