### PR TITLE
Include changelog in PyInstaller build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,6 +51,7 @@ jobs:
             --copy-metadata open_webui \
             --copy-metadata uvicorn \
             --hidden-import=uvicorn.logging \
+            --add-data CHANGELOG.md:open_webui/CHANGELOG.md \
             --collect-data open_webui
           status=$?
           if [ $status -ne 0 ] && [ "$RUNNER_OS" = "Linux" ]; then
@@ -66,6 +67,7 @@ jobs:
               --copy-metadata open_webui \
               --copy-metadata uvicorn \
               --hidden-import=uvicorn.logging \
+              --add-data CHANGELOG.md:open_webui/CHANGELOG.md \
               --collect-data open_webui
           fi
         shell: bash
@@ -114,6 +116,7 @@ jobs:
             --copy-metadata open_webui `
             --copy-metadata uvicorn `
             --hidden-import=uvicorn.logging `
+            --add-data CHANGELOG.md;open_webui/CHANGELOG.md `
             --collect-data open_webui
       - shell: pwsh
         run: Get-ChildItem dist-bin | Format-Table Name,Length


### PR DESCRIPTION
## Summary
- ensure CHANGELOG.md is bundled when building executables with PyInstaller

## Testing
- `pytest` (fails: ModuleNotFoundError: No module named 'test.util')
- `npm run test:frontend` (fails: vitest: not found)
- `npm ci` (fails: ERESOLVE could not resolve)


------
https://chatgpt.com/codex/tasks/task_e_68aad1e0aec4832d91a9fe1a0b2d7e48